### PR TITLE
add optional authorized team configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ You will need to decide the label that this app looks for, the contents of the i
 - `ISSUE_BODY_FILE`  This is the file containing the body of the issue created
 - `ISSUE_ASSIGNEES`  This is a comma separated list of the issue assignees
 
+Optionally, you can define a team name in the `AUTHORIZED_TEAM` variable. The app will consider members of this team authorized to use this app. The app will add a comment on the PR if an user who is not a member of this team attemps to do any of the following:  
+- Opens a PR with the `TRIGGER_STRING` in the body  
+- Adds a PR comment with the `TRIGGER_STRING` in the body  
+- Adds the `EMERGENCY_LABEL` to a PR  
+
+The comment will read:  
+```
+@username is not authorized to apply the emergency label.
+```
+
 To make the emergency label permanent set `EMERGENCY_LABEL_PERMANENT` to true. Doing this will cause the app to reapply the emergency label if it is removed.
 To trigger the label (and therefore everything configured) set `TRIGGER_STRING` to the value you want the app to look for in PRs and PR comments.
 

--- a/template.yml
+++ b/template.yml
@@ -75,6 +75,9 @@ Parameters:
     Description: The string value in a PR or Issue title that triggers appling the emegency label
     Default: emergency landing
     Type: String
+  authorizedTeam:
+    Description: The team who's members are authorized to use this app
+    Type: String
 
 Resources:
   webhooks:
@@ -108,6 +111,7 @@ Resources:
           SLACK_MESSAGE_FILE: !Ref slackMessageFile
           EMERGENCY_LABEL_PERMANENT: !Ref emergencyLabelPermanent
           TRIGGER_STRING: !Ref triggerString
+          AUTHORIZED_TEAM: !Ref authorizedTeam
 
 Outputs:
   WebhooksUrl:

--- a/test.js
+++ b/test.js
@@ -9,8 +9,8 @@ const {
   ProbotOctokit,
 } = require("@probot/adapter-aws-lambda-serverless");
 
-const payload = {
-  loadName: "payload",
+const payloadPrLabeled = {
+  loadName: "payloadPrLabeled",
   name: "pull_request",
   id: "1",
   payload: {
@@ -31,6 +31,43 @@ const payload = {
       html_url: "https://github.com/robandpdx/superbigmono/pull/1",
       merged: false
     },
+    organization: {
+      login: "robandpdx",
+    },
+    sender: {
+      login: "robandpdx",
+    }
+  },
+}
+
+const payloadPrLabeledByBot = {
+  loadName: "payloadPrLabeled",
+  name: "pull_request",
+  id: "1",
+  payload: {
+    action: "labeled",
+    label: {
+      name: "emergency"
+    },
+    repository: {
+      owner: {
+        login: "robandpdx",
+      },
+      name: "superbigmono",
+      url: "https://api.github.com/repos/robandpdx/superbigmono"
+    },
+    pull_request: {
+      number: 1,
+      url: "https://api.github.com/repos/robandpdx/superbigmono/pulls/1",
+      html_url: "https://github.com/robandpdx/superbigmono/pull/1",
+      merged: false
+    },
+    organization: {
+      login: "robandpdx",
+    },
+    sender: {
+      login: "emergency-pr[bot]",
+    }
   },
 }
 
@@ -54,6 +91,35 @@ const payloadUnlabeled = {
       },
       name: "superbigmono"
     },
+    sender: {
+      login: "robandpdx",
+    }
+  },
+}
+
+const payloadUnlabeledByBot = {
+  loadName: "payloadUnlabeledByBoy",
+  name: "pull_request",
+  id: "1",
+  payload: {
+    action: "unlabeled",
+    label: {
+      name: "emergency"
+    },
+    pull_request: {
+      number: 1,
+      issue_url: "https://api.github.com/repos/robandpdx/superbigmono/issues/1",
+      html_url: "https://github.com/robandpdx/superbigmono/pull/1",
+    },
+    repository: {
+      owner: {
+        login: "robandpdx",
+      },
+      name: "superbigmono"
+    },
+    sender: {
+      login: "emergency-pr[bot]",
+    }
   },
 }
 
@@ -77,6 +143,35 @@ const payloadIssueUnlabeled = {
       },
       name: "superbigmono"
     },
+    sender: {
+      login: "robandpdx",
+    }
+  },
+}
+
+const payloadIssueUnlabeledByBot = {
+  loadName: "payloadIssueUnlabeled",
+  name: "issues",
+  id: "1",
+  payload: {
+    action: "unlabeled",
+    label: {
+      name: "emergency"
+    },
+    issue: {
+      url: "https://api.github.com/repos/robandpdx/superbigmono/issues/1",
+      html_url: "https://github.com/robandpdx/superbigmono/pull/1",
+      number: 1,
+    },
+    repository: {
+      owner: {
+        login: "robandpdx",
+      },
+      name: "superbigmono"
+    },
+    sender: {
+      login: "emergency-pr[bot]",
+    }
   },
 }
 
@@ -98,6 +193,12 @@ const payloadPrOpened = {
       },
       name: "superbigmono"
     },
+    organization: {
+      login: "robandpdx",
+    },
+    sender: {
+      login: "robandpdx",
+    }
   }
 }
 
@@ -126,7 +227,25 @@ const payloadPrComment = {
       },
       name: "superbigmono"
     },
+    organization: {
+      login: "robandpdx",
+    },
+    sender: {
+      login: "robandpdx",
+    }
   }
+}
+
+const payloadMembershipResponse = {
+  "url": "https://api.github.com/teams/1/memberships/robandpdx",
+  "role": "maintainer",
+  "state": "active"
+}
+
+const payloadNonMembershipResponse = {
+  "url": "https://api.github.com/teams/1/memberships/robandpdx",
+  "role": "member",
+  "state": "inactive"
 }
 
 const app = require("./app");
@@ -165,6 +284,7 @@ test.after.each(() => {
   delete process.env.SLACK_NOTIFY;
   delete process.env.SLACK_MESSAGE_FILE;
   delete process.env.EMERGENCY_LABEL_PERMANENT;
+  delete process.env.AUTHORIZED_TEAM;
 });
 
 // This test sends a payload that is not an emergency label
@@ -177,6 +297,12 @@ test("recieves pull_request.labeled event, does nothing because not emergency la
       label: {
         name: "other"
       },
+      organization: {
+        login: 'robandpdx'
+      },
+      sender: { 
+        login: 'robandpdx'
+      }
     },
   });
 });
@@ -239,7 +365,7 @@ test("recieves pull_request.labeled event, approve, create issue, merge, slack n
       }
     });
 
-  await probot.receive(payload);
+  await probot.receive(payloadPrLabeled);
   assert.equal(mock.pendingMocks(), []);
   assert.equal(mockSlack.pendingMocks(), []);
 });
@@ -263,7 +389,7 @@ test("recieves pull_request.labeled event, approve PR", async function () {
     )
     .reply(200);
 
-  await probot.receive(payload);
+  await probot.receive(payloadPrLabeled);
   assert.equal(mock.pendingMocks(), []);
 });
 
@@ -284,7 +410,7 @@ test("recieves pull_request.labeled event, create issue", async function () {
     )
     .reply(200);
 
-  await probot.receive(payload);
+  await probot.receive(payloadPrLabeled);
   assert.equal(mock.pendingMocks(), []);
 });
 
@@ -306,7 +432,7 @@ test("recieves pull_request.labeled event, create issue no assignees", async fun
     )
     .reply(200);
 
-  await probot.receive(payload);
+  await probot.receive(payloadPrLabeled);
   assert.equal(mock.pendingMocks(), []);
 });
 
@@ -321,7 +447,107 @@ test("recieves pull_request.labeled event, merge the PR", async function () {
   const mock = nock("https://api.github.com")
     .put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
 
-  await probot.receive(payload);
+  await probot.receive(payloadPrLabeled);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will merge the PR because the user is a member of the emergency team
+test("recieves pull_request.labeled event, check team membership, merge the PR", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+  
+  // mock the request to add approval to the pr
+  const mock = nock("https://api.github.com")
+    .put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
+
+  // mock the request to check if the user is a member of the emergency team
+  mock.get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+  .reply(200, payloadMembershipResponse);
+
+  await probot.receive(payloadPrLabeled);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will merge the PR because label was applied by a bot
+test("recieves pull_request.labeled event from a bot, merge the PR", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+  
+  // mock the request to add approval to the pr
+  const mock = nock("https://api.github.com")
+    .put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
+
+  await probot.receive(payloadPrLabeledByBot);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will not merge the PR because the user is not a member of the emergency team
+test("recieves pull_request.labeled event, check non team membership, do not merge the PR", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+  
+  // mock the request to check if the user is a member of the emergency team
+  const mock = nock("https://api.github.com")
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+      .reply(200, payloadNonMembershipResponse);
+
+  // mock the request to create the issue comment
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@robandpdx is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(200);
+
+  // mock the request to delete the label
+  mock.delete("/repos/robandpdx/superbigmono/issues/1/labels/emergency",
+    (requestBody) => {
+      return true;
+    }
+  ).reply(200);
+
+  await probot.receive(payloadPrLabeled);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will not merge the PR because non team membership
+test("recieves pull_request.labeled event, non team membership, do not merge the PR", async function () {
+  process.env.APPROVE_PR = 'false';
+  process.env.CREATE_ISSUE = 'false';
+  process.env.MERGE_PR = 'true';
+  process.env.SLACK_NOTIFY = 'false';
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+  
+  // mock the request to check if the user is a member of the emergency team
+  const mock = nock("https://api.github.com")
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+      .reply(404);
+
+  // mock the request to create the issue comment
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@robandpdx is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(200);
+
+  // mock the request to delete the label
+  mock.delete("/repos/robandpdx/superbigmono/issues/1/labels/emergency",
+    (requestBody) => {
+      return true;
+    }
+  ).reply(200);
+
+  await probot.receive(payloadPrLabeled);
   assert.equal(mock.pendingMocks(), []);
 });
 
@@ -362,7 +588,7 @@ test("recieves pull_request.labeled event, slack notify", async function () {
       }
     });
 
-  await probot.receive(payload);
+  await probot.receive(payloadPrLabeled);
   assert.equal(mockSlack.pendingMocks(), []);
 });
 
@@ -386,7 +612,7 @@ test("recieves pull_request.labeled event, slack notify (fail)", async function 
     ).reply(500);
 
     try {
-      await probot.receive(payload);
+      await probot.receive(payloadPrLabeled);
     } catch (err) {
       assert.equal(mockSlack.pendingMocks(), []);
       assert.equal(err.errors[0][0].message, "An HTTP protocol error occurred: statusCode = 500");
@@ -423,7 +649,7 @@ test("recieves pull_request.labeled event, approve (fails), create issue, merge"
   mock.put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
 
   try {
-    await probot.receive(payload);
+    await probot.receive(payloadPrLabeled);
   } catch (err) {
     assert.equal(mock.pendingMocks(), []);
     assert.equal(err.errors[0][0].message, "request to https://api.github.com/repos/robandpdx/superbigmono/pulls/1/reviews failed, reason: something awful happened");
@@ -460,7 +686,7 @@ test("recieves pull_request.labeled event, approve, create issue (fails), merge"
   mock.put("/repos/robandpdx/superbigmono/pulls/1/merge").reply(200);
 
   try {
-    await probot.receive(payload);
+    await probot.receive(payloadPrLabeled);
   } catch (err) {
     assert.equal(mock.pendingMocks(), []);
     assert.equal(err.errors[0][0].message, "request to https://api.github.com/repos/robandpdx/superbigmono/issues failed, reason: something awful happened");
@@ -497,7 +723,7 @@ test("recieves pull_request.labeled event, approve, create issue, merge (fails)"
   mock.put("/repos/robandpdx/superbigmono/pulls/1/merge").replyWithError('something awful happened')
 
   try {
-    await probot.receive(payload);
+    await probot.receive(payloadPrLabeled);
   } catch (err) {
     assert.equal(mock.pendingMocks(), []);
     assert.equal(err.errors[0][0].message, "request to https://api.github.com/repos/robandpdx/superbigmono/pulls/1/merge failed, reason: something awful happened");
@@ -521,6 +747,13 @@ test("recieves pull_request.unlabeled event, reapply emergency label", async fun
 
   await probot.receive(payloadUnlabeled);
   assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will not reapply the emergency label to a PR if removed by bot
+test("recieves pull_request.unlabeled event from bot user, do not reapply emergency label", async function () {
+  process.env.EMERGENCY_LABEL_PERMANENT = 'true';
+
+  await probot.receive(payloadUnlabeledByBot);
 });
 
 // This test will fail to reapply the emergency label to a PR
@@ -571,6 +804,13 @@ test("recieves issue.unlabeled event, reapply emergency label", async function (
   assert.equal(mock.pendingMocks(), []);
 });
 
+// This test will not reapply the emergency label to an issue if removed by bot
+test("recieves issue.unlabeled event from bot, do not reapply emergency label", async function () {
+  process.env.EMERGENCY_LABEL_PERMANENT = 'true';
+
+  await probot.receive(payloadIssueUnlabeledByBot);
+});
+
 // This test will fail to reapply the emergency label to an issue
 test("recieves issue.unlabeled event, fail to reapply emergency label", async function () {
   process.env.EMERGENCY_LABEL_PERMANENT = 'true';
@@ -618,6 +858,49 @@ test("recieves pull_request.opened event, applies emergency label", async functi
   assert.equal(mock.pendingMocks(), []);
 });
 
+// This test will apply the emergency label based on the PR contents checking team membership
+test("recieves pull_request.opened event, applies emergency label checking team membership", async function () {
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // mock the request to apply the emergency label
+  const mock = nock("https://api.github.com")
+    .post("/repos/robandpdx/superbigmono/issues/1/labels",
+      (requestBody) => {
+        assert.equal(requestBody[0], "emergency");
+        return true;
+      }
+    )
+    .reply(200);
+
+  // mock the request to check if the user is a member of the emergency team
+  mock.get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+  .reply(200, payloadMembershipResponse);
+
+  await probot.receive(payloadPrOpened);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will not apply the emergency label due to non team membership
+test("recieves pull_request.opened event, does not apply emergency label due to non team membership", async function () {
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // mock the request to apply the emergency label
+  const mock = nock("https://api.github.com")
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+      .reply(200, payloadNonMembershipResponse);
+
+  // mock the request to create the issue comment
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@robandpdx is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(200);
+
+  await probot.receive(payloadPrOpened);
+  assert.equal(mock.pendingMocks(), []);
+});
+
 // This test will fail to apply the emergency label based on the PR contents
 test("recieves pull_request.opened event, fails to apply emergency label", async function () {
   // mock the request to apply the emergency label
@@ -659,6 +942,92 @@ test("recieves issue_comment.created event, applies emergency label", async func
     .reply(200);
 
   await probot.receive(payloadPrComment);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will apply the emergency label based on the contents of a comment on the PR, checking team membership
+test("recieves issue_comment.created event, applies emergency label", async function () {
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // mock the request to apply the emergency label
+  const mock = nock("https://api.github.com")
+    .post("/repos/robandpdx/superbigmono/issues/1/labels",
+      (requestBody) => {
+        assert.equal(requestBody[0], "emergency");
+        return true;
+      }
+    )
+    .reply(200);
+
+  // mock the request to check if the user is a member of the emergency team
+  mock.get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+  .reply(200, payloadMembershipResponse);
+
+  await probot.receive(payloadPrComment);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will not apply the emergency label due to non team membership and comment
+test("recieves issue_comment.created event, does not apply emergency label due to non membership", async function () {
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // mock the request to apply the emergency label
+  const mock = nock("https://api.github.com")
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+      .reply(200, payloadNonMembershipResponse);
+
+  // mock the request to create the issue comment
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@robandpdx is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(200);
+
+  await probot.receive(payloadPrComment);
+  assert.equal(mock.pendingMocks(), []);
+});
+
+// This test will not apply the emergency label due failed membership check
+test("recieves issue_comment.created event, does not apply emergency label due to failed membership check", async function () {
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // mock the request to apply the emergency label
+  const mock = nock("https://api.github.com")
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+      .reply(500);
+
+  try {
+    await probot.receive(payloadPrComment);
+  } catch (err) {
+    assert.equal(mock.pendingMocks(), []);
+    assert.equal(err.errors[0].message, "Error checking membership");
+  }
+});
+
+// This test will not apply the emergency label due to non team membership, fail to comment
+test("recieves issue_comment.created event, does not applies emergency label, fail to comment", async function () {
+  process.env.AUTHORIZED_TEAM = 'emergency-team'
+
+  // mock the request to apply the emergency label
+  const mock = nock("https://api.github.com")
+    .get(`/orgs/robandpdx/teams/emergency-team/memberships/robandpdx?org=robandpdx&team_slug=emergency-team&username=robandpdx`)
+      .reply(200, payloadNonMembershipResponse);
+
+  // mock the request to create the issue comment
+  mock.post("/repos/robandpdx/superbigmono/issues/1/comments",
+    (requestBody) => {
+      assert.equal(requestBody.body, "@robandpdx is not authorized to apply the emergency label.");
+      return true;
+    }
+  ).reply(404);
+  
+  try {
+    await probot.receive(payloadPrComment);
+  } catch (err) {
+    assert.equal(mock.pendingMocks(), []);
+    assert.equal(err.errors.length, 1);
+  }
   assert.equal(mock.pendingMocks(), []);
 });
 


### PR DESCRIPTION
This pull request introduces an option to configure an `AUTHORIZED_TEAM` which the application will check the users membership of in order to act. The changes are centered around the `app.js` file, with corresponding updates to the `README.md`, `template.yml`, and `test.js` files to reflect the new functionality. 

The main changes include:

Authorization Mechanism:

* <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL15-R18">`app.js`</a>: Added an authorization check to various actions such as opening a pull request, adding a comment, and adding the `EMERGENCY_LABEL`. This check verifies if the user performing the action is a member of the authorized team specified in the `AUTHORIZED_TEAM` environment variable. If the user is not authorized, a comment is posted on the PR and the emergency label is removed if it was added. This authorization mechanism is implemented in the `isAuthorized()` function. <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL15-R18">[1]</a> <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fR128-R146">[2]</a> <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL159-R179">[3]</a> <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL189-R212">[4]</a> <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fR235-R246">[5]</a> <a href="diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fR269-R339">[6]</a>

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R81">`README.md`</a>: Updated the documentation to explain the new `AUTHORIZED_TEAM` environment variable and the authorization mechanism.

* <a href="diffhunk://#diff-a2966abb566e0e66c18df93baeb68786f64e2f7f5d2cafb80df11c9a81f47238R78-R80">`template.yml`</a>: Added the `AUTHORIZED_TEAM` parameter to the AWS SAM template. <a href="diffhunk://#diff-a2966abb566e0e66c18df93baeb68786f64e2f7f5d2cafb80df11c9a81f47238R78-R80">[1]</a> <a href="diffhunk://#diff-a2966abb566e0e66c18df93baeb68786f64e2f7f5d2cafb80df11c9a81f47238R114">[2]</a>

Test Cases:

* <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L12-R13">`test.js`</a>: Updated and added new test cases to cover the new authorization mechanism. <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L12-R13">[1]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R34-R70">[2]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R94-R122">[3]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R146-R174">[4]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R196-R201">[5]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R230-R250">[6]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R287">[7]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R300-R305">[8]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L242-R368">[9]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L266-R392">[10]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L287-R413">[11]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L309-R435">[12]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L324-R550">[13]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R287">[14]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R300-R305">[15]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L242-R368">[16]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L266-R392">[17]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L287-R413">[18]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L309-R435">[19]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L324-R550">[20]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R287">[21]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R300-R305">[22]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L242-R368">[23]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L266-R392">[24]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L287-R413">[25]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L309-R435">[26]</a> <a href="diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L324-R550">[27]</a>