### PR TITLE
pin nyc-reporter-action to SHA

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
         cache: npm
     - run: npm ci
     - run: npm test
-    - uses: tintef/nyc-reporter-action@0.2.5
+    - uses: tintef/nyc-reporter-action@66a40cea2d02fdb0ac8fa045a7355cbbf9b991a1
       with:
         GITHUB_TOKEN: ${{ github.token }}
         SKIP_COVERAGE_FOLDER: true


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr.yml` file. The change updates the version of the `tintef/nyc-reporter-action` used in the workflow.