### PR TITLE
GITHUB_USER and GITHUB_PAT are no longer needed

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -4,9 +4,6 @@ WEBHOOK_PROXY_URL=
 APP_ID=
 WEBHOOK_SECRET=
 PRIVATE_KEY=
-# GutHub User
-GITHUB_PAT=
-GITHUB_USER=
 # Slack App
 SLACK_BOT_TOKEN=
 # Functionality flags

--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ Get the following details about your GitHub app:
 
 You will need to base64 encode the private key.
 
-You will also need a user and PAT with admin permissions on the repos in order to merge bypassing checks and required approvals. These will be supplied to the app as the following env vars:
-- `GITHUB_USER`
-- `GITHUB_PAT`
-
 Get the following details about your Slack app:
 - `SLACK_BOT_TOKEN`
 
@@ -129,8 +125,6 @@ docker run \
     -e APP_ID=$APP_ID \
     -e PRIVATE_KEY=$PRIVATE_KEY \
     -e WEBHOOK_SECRET=$WEBHOOK_SECRET \
-    -e GITHUB_PAT=$GITHUB_PAT \
-    -e GITHUB_USER=$GITHUB_USER \
     -e APPROVE_PR=$APPROVE_PR \
     -e CREATE_ISSUE=$CREATE_ISSUE \
     -e MERGE_PR=$MERGE_PR \

--- a/app.js
+++ b/app.js
@@ -1,8 +1,4 @@
 const fs = require('fs')
-const auth = {
-  username: process.env.GITHUB_USER,
-  password: process.env.GITHUB_PAT
-}
 
 const emergencyLabel = process.env.EMERGENCY_LABEL || 'emergency';
 


### PR DESCRIPTION
This pull request removes the requirement for GitHub user and personal access token (PAT) credentials from the project configuration and documentation. The most important changes include updates to the `.env-sample` file, the `README.md` file, and the `app.js` file.