### PR TITLE
Node24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.195.0/containers/javascript-node/.devcontainer/base.Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=20-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+ARG VARIANT=24-trixie
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends python pip
+     && apt-get -y install --no-install-recommends python3 python3-pip python-is-python3 pipx
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
@@ -16,5 +16,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Intall aws cli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install
-# Install sam cli
-RUN pip install aws-sam-cli
+# Install sam cli (use pipx because Debian Trixie's Python is PEP 668 externally-managed)
+RUN PIPX_HOME=/usr/local/pipx PIPX_BIN_DIR=/usr/local/bin pipx install aws-sam-cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
-		"args": { "VARIANT": "20-bullseye" }
+		"args": { "VARIANT": "24-trixie" }
 	},
 
 	"settings": {},

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         check-latest: true
         cache: npm
     - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci

--- a/handler.js
+++ b/handler.js
@@ -1,10 +1,20 @@
 const {
   createLambdaFunction,
   createProbot,
+  ProbotOctokit,
 } = require("@probot/adapter-aws-lambda-serverless");
 
 const appFn = require("./");
 
+const Octokit = ProbotOctokit.defaults({
+  userAgent: "emergency-pull-request-probot-app",
+  request: {
+    headers: {
+      "X-GitHub-Api-Version": "2026-03-10",
+    },
+  },
+});
+
 module.exports.webhooks = createLambdaFunction(appFn, {
-  probot: createProbot(),
+  probot: createProbot({ overrides: { Octokit } }),
 });

--- a/template.yml
+++ b/template.yml
@@ -87,7 +87,7 @@ Resources:
       Description: Basic Auth Funtion
       CodeUri: .
       Handler: handler.webhooks
-      Runtime: nodejs20.x
+      Runtime: nodejs24.x
       MemorySize: 256
       Timeout: 20
       Events:

--- a/test.js
+++ b/test.js
@@ -328,6 +328,11 @@ test.before.each(() => {
     Octokit: ProbotOctokit.defaults({
       throttle: { enabled: false },
       retry: { enabled: false },
+      request: {
+        headers: {
+          "X-GitHub-Api-Version": "2026-03-10",
+        },
+      },
     }),
   });
   probot.load(app);


### PR DESCRIPTION
This pull request upgrades the project environment and dependencies to Node.js 24 and Debian Trixie, updates the AWS Lambda runtime, and ensures compatibility with newer Python packaging standards. It also standardizes the use of a custom `Octokit` instance with a specific GitHub API version header across both production and test code.

**Environment and Dependency Upgrades:**

* Upgraded the development container to use Node.js 24 and Debian Trixie by updating the `VARIANT` argument in `.devcontainer/Dockerfile` and `.devcontainer/devcontainer.json`. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L3-R8) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L10-R10)
* Updated GitHub Actions workflows to use Node.js version 24 for both PR and test pipelines. [[1]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L24-R24) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18)
* Changed the AWS Lambda runtime in `template.yml` from `nodejs20.x` to `nodejs24.x` to match the new Node.js version.

**Python and AWS SAM CLI Installation:**

* Modified the devcontainer setup to install Python 3, `python-is-python3`, `python3-pip`, and `pipx` instead of legacy Python packages, and now installs `aws-sam-cli` via `pipx` to comply with Debian Trixie’s PEP 668 externally-managed environment. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L3-R8) [[2]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L19-R20)

**GitHub API Versioning and Octokit Configuration:**

* Updated both `handler.js` and test setup to use a custom `Octokit` instance with a user agent and the `X-GitHub-Api-Version: 2026-03-10` header, ensuring consistent API versioning in production and tests. [[1]](diffhunk://#diff-b1ac3fedd1274c707e03d180050c74671bf90fb3c56a201ea5c460dafe7e0d54R4-R19) [[2]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R331-R335)